### PR TITLE
Fix dotnet version mismatch by asking for the specific devcontainer and specify yarn as npm package manager

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
   "name": "Sonarr",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
+  "image": "mcr.microsoft.com/dotnet/sdk:8.0.404",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "nodeGypDependencies": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "npm.packageManager": "yarn"
 }


### PR DESCRIPTION
Two small issues: global.json specifies a more granular dotnet sdk version than the devcontainer config which led (for me and likely for others) to a mismatch: I got 8.0.111 -- the fix is just to ask for the devcontainer with the specific SDK version we need.

Yarn was not set as the npm package manager in the vscode settings, and vscode now defaults to pnpm, which is not installed in the devcontainer and caused another error.